### PR TITLE
Fix label resize on scene changed

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -61,6 +61,10 @@ H5P.ThreeImage = (function () {
         </H5PContext.Provider>,
         wrapper
       );
+
+      window.requestAnimationFrame(() => {
+        this.trigger('resize');
+      });
     };
 
     const createElements = () => {


### PR DESCRIPTION
Currently, when changing scenes, the labels don't get the proper font size as it needs to be computed. Fixed.