### PR TITLE
Set `type=button` on button elements to prevent form submissions

### DIFF
--- a/scripts/components/Dialog/Dialog.js
+++ b/scripts/components/Dialog/Dialog.js
@@ -58,6 +58,7 @@ export default class Dialog extends React.Component {
             { children }
           </div>
           <button
+            type="button"
             ref={ el => this.closeButton = el }
             aria-label={ this.context.l10n.closeDialog }
             className='close-button-wrapper'

--- a/scripts/components/HUD/Buttons/Button/Button.js
+++ b/scripts/components/HUD/Buttons/Button/Button.js
@@ -28,6 +28,7 @@ export default class AudioButton extends React.Component {
     return (
       <div className="btn-wrap">
         <button
+          type="button"
           ref={ el => this.element = el }
           className={ 'hud-btn ' + this.props.type }
           onClick={ this.handleClick }

--- a/scripts/components/Shared/ContextMenu.js
+++ b/scripts/components/Shared/ContextMenu.js
@@ -22,6 +22,7 @@ export default class ContextMenu extends Component {
         {
           this.props.isGoToScene &&
           <button
+            type="button"
             className='go-to-scene'
             onClick={this.goToScene.bind(this)}
             tabIndex="-1"
@@ -30,6 +31,7 @@ export default class ContextMenu extends Component {
           </button>
         }
         <button
+          type="button"
           className='edit'
           onClick={this.handlEdit.bind(this)}
           tabIndex="-1"
@@ -37,6 +39,7 @@ export default class ContextMenu extends Component {
           <div className='tooltip' dangerouslySetInnerHTML={{ __html: this.context.extras.l10n.edit }} />
         </button>
         <button
+          type="button"
           className='delete'
           onClick={this.handleDelete.bind(this)}
           tabIndex="-1"

--- a/scripts/components/Shared/NavigationButton.js
+++ b/scripts/components/Shared/NavigationButton.js
@@ -327,6 +327,7 @@ export default class NavigationButton extends React.Component {
         onBlur={this.onBlur.bind(this)}
       >
         <button
+          type="button"
           ref={this.navButton}
           aria-label={labelText ? labelText : title}
           className='nav-button'

--- a/scripts/components/Shared/NavigationButtonLabel.js
+++ b/scripts/components/Shared/NavigationButtonLabel.js
@@ -244,6 +244,7 @@ export default class NavigationButtonLabel extends React.Component {
         </div>
         {canExpand && !hoverOnly &&
           <button
+            type="button"
             onFocus={() => this.props.onFocus(true)}
             onBlur={() => this.props.onBlur(false)}
             ref={this.props.forwardRef}


### PR DESCRIPTION
Fixes #24

This is a problem in h5p environments wrapped by Webforms only, however this change doesn't make a difference in other environments.