### PR TITLE
HFP-3218 Stop setting focus on startup

### DIFF
--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -141,6 +141,7 @@ export default class Main extends React.Component {
     this.setState({
       sceneWaitingForLoad: this.props.currentScene,
       focusedInteraction: null,
+      childrenCanTakeFocus: true
     });
     let nextSceneId = null;
     if (sceneId === SceneTypes.PREVIOUS_SCENE) {
@@ -411,6 +412,7 @@ export default class Main extends React.Component {
                 isEditingInteraction={this.state.isEditingInteraction}
                 sceneWaitingForLoad={this.state.sceneWaitingForLoad}
                 doneLoadingNextScene={this.doneLoadingNextScene.bind(this)}
+                canTakeFocus={this.state.childrenCanTakeFocus}
               />
             );
           })

--- a/scripts/components/Scene/Scene.js
+++ b/scripts/components/Scene/Scene.js
@@ -31,6 +31,7 @@ export default class Scene extends React.Component {
           focusedInteraction={this.props.focusedInteraction}
           sceneWaitingForLoad={this.props.sceneWaitingForLoad}
           doneLoadingNextScene={this.props.doneLoadingNextScene}
+          canTakeFocus={this.props.canTakeFocus}
         />
       );
     }
@@ -59,6 +60,7 @@ export default class Scene extends React.Component {
         isEditingInteraction={this.props.isEditingInteraction}
         sceneWaitingForLoad={this.props.sceneWaitingForLoad}
         doneLoadingNextScene={this.props.doneLoadingNextScene}
+        canTakeFocus={this.props.canTakeFocus}
       />
     );
   }

--- a/scripts/components/Scene/SceneTypes/StaticScene.js
+++ b/scripts/components/Scene/SceneTypes/StaticScene.js
@@ -277,7 +277,9 @@ export default class StaticScene extends React.Component {
     this.setState({
       isVerticalImage: ratio < this.context.getRatio(),
     });
-    imageElement.focus();
+    if (this.props.canTakeFocus) {
+      imageElement.focus();
+    }
 
     this.context.on('resize', () => {
       this.setState({

--- a/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
+++ b/scripts/components/Scene/SceneTypes/ThreeSixtyScene.js
@@ -181,7 +181,10 @@ export default class ThreeSixtyScene extends React.Component {
       this.setState({
         isRendered: true
       });
-      threeSixty.focus();
+
+      if (this.props.canTakeFocus) {
+        threeSixty.focus();
+      }
     });
 
     threeSixty.startRendering();


### PR DESCRIPTION
When merged in, will not set focus on a scene on startup in order to prevent jumping on a page.