### PR TITLE
VA-1039 Filter out scenes without a background image

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -20,6 +20,11 @@ H5P.ThreeImage = (function () {
     // Initialize event inheritance
     H5P.EventDispatcher.call(self);
 
+    // Filter out scenes without a background image
+    params.threeImage.scenes = params.threeImage.scenes.filter((scene) => {
+      return scene.scenesrc?.path;
+    });
+
     let wrapper;
     this.behavior = {
       label: {


### PR DESCRIPTION
When merged in, will add a rather hotfix for crashes when a scene is saved without a background image.